### PR TITLE
Expose templates directory as volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN find /etc/service -type f -name 'run' -a ! -executable -exec chmod +x {} \;
 RUN rm -v /etc/nginx/conf.d/*
 ADD nginx.conf /etc/nginx/nginx.conf
 
+VOLUME /etc/consul-templates
+
 CMD ["my_init"]


### PR DESCRIPTION
Exposing the templates directory as a volume allows for this image to be inherited as well as run with a volume containing the app nginx template.
